### PR TITLE
autoreconf, don't force update

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cp README.md README
-autoreconf -vfi && \
+autoreconf -vi && \
 autoconf && {
   echo "Running configure with --enable-maintainer-mode $@"
   ./configure --enable-maintainer-mode $@


### PR DESCRIPTION
the use of autoreconf's '-f, --force consider all files obsolete' flag seems at odds with use of an old version of 'elisp-comp'. the resulting modifications to the file appear harmless but it causes the repo to have a modified status which gets in the way of further (git pull) updates

note that emacs-dbgr's autogen.sh call to autoreconf doesn't force obsolete status on all files
