### PR TITLE
Use %S to print expected/actual message.

### DIFF
--- a/test-simple.el
+++ b/test-simple.el
@@ -183,7 +183,7 @@ out information from the previous run."
 		  (format "Message: %s" fail-message)
 		""))
 	     (expect-message
-	      (format "\n  Expected: %s\n  Got: %s" expected actual))
+	      (format "\n  Expected: %S\n  Got: %S" expected actual))
 	     (test-info-mess
 	      (if (boundp 'test-info)
 		  (test-info-description test-info)


### PR DESCRIPTION
(assert-equal '("foo") '("bar"))
shows
  Expected: ("foo")
  Got: ("bar")

I LOVE this testing framework.
I use it for state.el test (test-start.el).
Thank you.