### PR TITLE
TAP output in batch mode now goes to stdout, not stderr

### DIFF
--- a/test-simple.el
+++ b/test-simple.el
@@ -289,13 +289,17 @@ additional message to be displayed."
   (interactive)
   (unless test-info (setq test-info test-simple-info))
   (test-simple-describe-failures test-info)
-  (if noninteractive
-      (progn
-	(switch-to-buffer "*test-simple*")
-	(message "%s" (buffer-substring (point-min) (point-max)))
-	)
-    (switch-to-buffer-other-window "*test-simple*")
-    ))
+  (cond (noninteractive
+         (set-buffer "*test-simple*")
+         (cond ((getenv "USE_TAP")
+                (princ (format "%s\n" (buffer-string)))
+                )
+               (t ;; non-TAP goes to stderr (backwards compatibility)
+              	(message "%s" (buffer-substring (point-min) (point-max)))
+                )))
+        (t ;; interactive
+         (switch-to-buffer-other-window "*test-simple*")
+         )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Reporting


### PR DESCRIPTION
A change to end-tests so that with USE_TAP enabled, batch mode output  goes to stdout, as specified by the TAP standard. This makes it possible to write command-line tests in elisp that can be run with tools such as prove.   Batch mode output without USE_TAP still goes to stderr.  