### PR TITLE
Use `with-current-buffer` in `test-simple-msg`

### DIFF
--- a/test-simple.el
+++ b/test-simple.el
@@ -298,12 +298,11 @@ additional message to be displayed."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun test-simple-msg(msg &optional newline)
-  (switch-to-buffer "*test-simple*")
-  (let ((inhibit-read-only t))
+  (with-current-buffer "*test-simple*"
+    (let ((inhibit-read-only t))
     (insert msg)
     (if newline (insert "\n"))
-    (switch-to-buffer nil)
-  ))
+  )))
 
 (defun test-simple--ok-msg (fail-message &optional test-info)
   (unless test-info (setq test-info test-simple-info))

--- a/test/test-buffer.el
+++ b/test/test-buffer.el
@@ -1,0 +1,26 @@
+;;; test-simple.el --- Simple Unit Test Framework for Emacs Lisp
+;; Copyright (C) 2023 Free Software Foundation, Inc
+;; Author: 813gan
+;; This program is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see
+;; <http://www.gnu.org/licenses/>.
+(load-file "../test-simple.el")
+(test-simple-start "test-simple.el")
+
+(note "make sure test-simple don't flush buffer")
+(with-temp-buffer
+  (insert "test")
+  (assert-t 't)
+  (assert-nil (equal (point-min) (point-max)) "test-simple is breaking buffers.") )
+
+(end-tests)


### PR DESCRIPTION
`switch-to-buffer` for some reason breaks tests using `with-temp-buffer`.